### PR TITLE
修复某些站（如岛）可能误下到非免费种的问题

### DIFF
--- a/nexusphp.py
+++ b/nexusphp.py
@@ -277,8 +277,15 @@ class NexusPHP(object):
     @staticmethod
     def generate_discount_fn(convert):
         def fn(page):
-            for key, value in convert.items():
+				'''
                 if key in page.text:
+                    return value
+                '''
+				# by csupxh 2019.08.31
+				# 仅匹配id为top节点的折扣信息，防止误匹配到该折扣信息的其它版本种子（种子详情页下面有一个'其它版本'表）
+                sp = get_soup(page.text)
+                top = sp.find(id='top')
+                if top is not None and key in top.decode():
                     return value
             return None
 


### PR DESCRIPTION
修复某些站（如岛）可能误下到非免费种的问题：
'pro_free' class属性除了在头部id='top'节点下出现外，如果该种子含有其他版本种子，且其他版本种子是免费，那么'pro_free'也可能在'其它版本'表中出现。
因此，待下载种子不免费，但只要该种子含有其他版本的免费种子，那么该非免费种有可能会误下载